### PR TITLE
fixed MailAllowlist.delivering_email to accept a single string in the mail.to attribute

### DIFF
--- a/lib/mail_allowlist.rb
+++ b/lib/mail_allowlist.rb
@@ -13,7 +13,8 @@ class MailAllowlist
   end
 
   def delivering_email(mail)
-    mail.to = mail.to.select { |recipient| allowlisted?(recipient) }
+    mail_to = mail.to.respond_to?(:select) ? mail.to : [mail.to]
+    mail.to = mail_to.select { |recipient| allowlisted?(recipient) }
     mail.to = [fallback] unless mail.to.any?
   end
 

--- a/spec/mail_allowlist_spec.rb
+++ b/spec/mail_allowlist_spec.rb
@@ -32,4 +32,10 @@ RSpec.describe MailAllowlist do
     expect { mail_allowlist.delivering_email(email) }
       .to change { email.to }.to(['terry@example.com'])
   end
+
+  it 'will accept 1 to address as a string' do
+    email = OpenStruct.new(to: '<Grahham> graham@example.com')
+    expect { mail_allowlist.delivering_email(email) }
+      .to change { email.to }.to(['terry@example.com'])
+  end
 end


### PR DESCRIPTION
While using this gem I found that if I passed in a email with a presentation name (ie: `'<John Doe> john.doe@test.com'`) it gets passed to `delivering_email` as string instead of an array of strings. 